### PR TITLE
User name is not email anymore

### DIFF
--- a/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -80,7 +80,10 @@ namespace UserManagementTestApp.Areas.Identity.Pages.Account
             {
                 // This doesn't count login failures towards account lockout
                 // To enable password failures to trigger account lockout, set lockoutOnFailure: true
-                var result = await _signInManager.PasswordSignInAsync(Input.Email, Input.Password, Input.RememberMe, lockoutOnFailure: false);
+
+                AppUser loginUser = await _userManager.FindByEmailAsync(Input.Email);
+                
+                var result = await _signInManager.PasswordSignInAsync(loginUser, Input.Password, Input.RememberMe, true);
                 if (result.Succeeded)
                 {
                     _logger.LogInformation("User logged in.");

--- a/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -83,9 +83,11 @@ namespace UserManagementTestApp.Areas.Identity.Pages.Account
             ExternalLogins = (await _signInManager.GetExternalAuthenticationSchemesAsync()).ToList();
             if (ModelState.IsValid)
             {
+                string newUserName = $"{Input.FirstName} {Input.LastName.Substring(0, 1)}.";
+
                 var user = new AppUser 
-                    { 
-                        UserName = Input.Email, 
+                    {
+                        UserName = newUserName, 
                         Email = Input.Email, 
                         FirstName = Input.FirstName, 
                         LastName = Input.LastName

--- a/Startup.cs
+++ b/Startup.cs
@@ -32,7 +32,11 @@ namespace UserManagementTestApp
                 options.UseSqlServer(
                     Configuration.GetConnectionString("LocalConnection")));
 
-            services.AddIdentity<AppUser, IdentityRole<int>>(options => options.SignIn.RequireConfirmedAccount = false)
+            services.AddIdentity<AppUser, IdentityRole<int>>(options =>
+                {
+                    options.SignIn.RequireConfirmedAccount = false;
+                    
+                })
                 .AddEntityFrameworkStores<AppDbContext>()
                 .AddDefaultTokenProviders()
                 .AddDefaultUI();
@@ -41,6 +45,12 @@ namespace UserManagementTestApp
             {
                 options.User.RequireUniqueEmail = true;
                 options.User.AllowedUserNameCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+ ";
+                
+                // Lockout options:
+                options.Lockout.AllowedForNewUsers = true;
+                options.Lockout.DefaultLockoutTimeSpan = TimeSpan.FromMinutes(10);
+                options.Lockout.MaxFailedAccessAttempts = 3;
+
             });
             
             services.AddRazorPages();

--- a/Startup.cs
+++ b/Startup.cs
@@ -36,6 +36,12 @@ namespace UserManagementTestApp
                 .AddEntityFrameworkStores<AppDbContext>()
                 .AddDefaultTokenProviders()
                 .AddDefaultUI();
+
+            services.Configure<IdentityOptions>(options =>
+            {
+                options.User.RequireUniqueEmail = true;
+                options.User.AllowedUserNameCharacters = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-._@+ ";
+            });
             
             services.AddRazorPages();
         }


### PR DESCRIPTION
Hi.
Originally, EF Core takes the email address as username. This would also result in a publicly displayed email address, which is not allowed nor desired. 
This change sets the user name during the registration to first name and the first digit of the last name, e.g. John D. I think we talked about clear names insted of phantasy user names.

Lockout options updated:
User will be locked out for 10 minutes after 3 failed login attempts.

NB: No db update required for this change. However, it contains my last migration..